### PR TITLE
Remove .html from all urls and links

### DIFF
--- a/_data/sidebars/main_sidebar.yml
+++ b/_data/sidebars/main_sidebar.yml
@@ -11,21 +11,21 @@ entries:
     type: frontmatter
     folderitems:
     - title:
-      url: /titlepage.html
+      url: /titlepage
       output: pdf
       type: frontmatter
     - title:
-      url: /tocpage.html
+      url: /tocpage
       output: pdf
       type: frontmatter
 
   - title: Introduction
-    url: /index.html
+    url: /
     output: toplevel, pdf
     type: homepage
 
   - title: Platform Overview
-    url: /overview.html
+    url: /overview
     output: toplevel, pdf
 
   - title: Tutorials
@@ -33,43 +33,43 @@ entries:
     folderitems:
 
     - title: Quick Guide
-      url: /quick_guide.html
+      url: /quick_guide
       output: web, pdf
 
     - title: Deployment with Exoframe
-      url: /exoframe.html
+      url: /exoframe
       output: web, pdf
 
     - title: Using Master Instance
-      url: /master.html
+      url: /master
       output: web, pdf
 
     - title: Benchmarking a System
-      url: /benchmarking.html
+      url: /benchmarking
       output: web, pdf
 
     - title: Browsing Results
-      url: /browsing_results.html
+      url: /browsing_results
       output: web, pdf
 
     - title: Taking Part in Challenge
-      url: /challenge_participation.html
+      url: /challenge_participation
       output: web, pdf
 
     - title: Organizing a Challenge
-      url: /challenge_organization.html
+      url: /challenge_organization
       output: web, pdf
 
     - title: How to Integrate a System
-      url : /system_integration.html
+      url : /system_integration
       output: web, pdf
 
     - title: How to Integrate a Benchmark
-      url : /benchmark_integration.html
+      url : /benchmark_integration
       output: web, pdf
 
     - title: Using Java SDK to develop a Benchmark
-      url : /java_sdk.html
+      url : /java_sdk
       output: web, pdf
 
   - title: Reference Manual
@@ -77,7 +77,7 @@ entries:
     folderitems:
 
     - title: Workflow of an Experiment
-      url: /experiment_workflow.html
+      url: /experiment_workflow
       output: web, pdf
 
       subfolders:
@@ -86,43 +86,43 @@ entries:
           subfolderitems:
 
             - title: Requirements
-              url: /requirements.html
+              url: /requirements
               output: web, pdf
 
             - title: On a Single Machine
-              url: /platform_deployment_single_machine.html
+              url: /platform_deployment_single_machine
               output: web, pdf
 
             - title: On a Cluster
-              url: /platform_deployment_cluster.html
+              url: /platform_deployment_cluster
               output: web, pdf
 
             - title: Troubleshooting
-              url: /troubleshooting.html
+              url: /troubleshooting
               output: web, pdf
 
             - title: Optional platform features
-              url: /optional_features.html
+              url: /optional_features
               output: web, pdf
-            
+
             - title: Env. Variables
-              url: /parameters_env.html
+              url: /parameters_env
               output: web, pdf
 
             - title: Platform Config File
-              url: /parameters_config.html
+              url: /parameters_config
               output: web, pdf
 
             - title: Volumes
-              url: /parameters_volumes.html
+              url: /parameters_volumes
               output: web, pdf
 
             - title: storage-init.sh
-              url: /parameters_storage_init.html
+              url: /parameters_storage_init
               output: web, pdf
 
             - title: Frontend configuration
-              url: /parameters_frontend.html
+              url: /parameters_frontend
               output: web, pdf
 
         - title: Platform Components
@@ -130,43 +130,43 @@ entries:
           subfolderitems:
 
             - title: Platform Controller
-              url: /platform_controller_component.html
+              url: /platform_controller_component
               output: web, pdf
 
             - title: Storage
-              url: /storage_component.html
+              url: /storage_component
               output: web, pdf
 
             - title: Frontend
-              url: /frontend_component.html
+              url: /frontend_component
               output: web, pdf
 
             - title: User Management
-              url: /user_management_component.html
+              url: /user_management_component
               output: web, pdf
 
             - title: Repository
-              url: /repository_component.html
+              url: /repository_component
               output: web, pdf
 
             - title: Analysis
-              url: /analysis_component.html
+              url: /analysis_component
               output: web, pdf
 
             - title: Message Bus
-              url: /message_bus_component.html
+              url: /message_bus_component
               output: web, pdf
 
             - title: Logging
-              url: /logging_component.html
+              url: /logging_component
               output: web, pdf
 
             - title: Resource Monitoring
-              url: /monitoring_component.html
+              url: /monitoring_component
               output: web, pdf
 
             - title: Internal Challenge Workflow
-              url: /internal_challenge_workflow.html
+              url: /internal_challenge_workflow
               output: web, pdf
 
         - title: Core Library
@@ -174,31 +174,29 @@ entries:
           subfolderitems:
 
             - title: Java Components
-              url: /java_components.html
+              url: /java_components
               output: web, pdf
 
             - title: Command Queue
-              url: /command_queue.html
+              url: /command_queue
               output: web, pdf
 
             - title: Transferring Data
-              url: /transferring_data.html
+              url: /transferring_data
               output: web, pdf
 
     - title: General Platform API
-      url: /platform_api.html
+      url: /platform_api
       output: web, pdf
 
     - title: Integrating a System
-      url: /system_integration_api.html
+      url: /system_integration_api
       output: web, pdf
 
     - title: Integrating a Benchmark
-      url: /benchmark_integration_api.html
+      url: /benchmark_integration_api
       output: web, pdf
 
     - title: FAQ
-      url: /faq.html
+      url: /faq
       output: web, pdf
-    
-

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -6,4 +6,4 @@
 #     - title: GitHub
 #       external_url: https://github.com/hobbit-project
 #     - title: HOBBIT Documentation
-#       url: /introduction.html
+#       url: /introduction

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="fa fa-home fa-lg navbar-brand" href="index.html">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
+            <a class="fa fa-home fa-lg navbar-brand" href=".">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">

--- a/pages/docs/analysis_component.md
+++ b/pages/docs/analysis_component.md
@@ -3,7 +3,7 @@ title: Analysis Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: analysis_component.html
+permalink: analysis_component
 folder: docs
 ---
 

--- a/pages/docs/benchmark_integration.md
+++ b/pages/docs/benchmark_integration.md
@@ -3,11 +3,11 @@ title: How to integrate a Benchmark
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: benchmark_integration.html
+permalink: benchmark_integration
 folder: docs
 ---
 
-This article shows how to use the provided abstract classes to implement the different benchmark components using the interfaces and classes from the [core library](https://github.com/hobbit-project/core) of the HOBBIT platform. The role of the different components is described in the [overview article](/overview.html) If you haven't took a look at the [general development of a component in java](/java_components.html) you should do this before reading this article.
+This article shows how to use the provided abstract classes to implement the different benchmark components using the interfaces and classes from the [core library](https://github.com/hobbit-project/core) of the HOBBIT platform. The role of the different components is described in the [overview article](/overview) If you haven't took a look at the [general development of a component in java](/java_components) you should do this before reading this article.
 
 * [Data Generator](#data-generator)
 * [Task Generator](#task-generator)

--- a/pages/docs/benchmark_integration_api.md
+++ b/pages/docs/benchmark_integration_api.md
@@ -3,7 +3,7 @@ title: Integrating a Benchmark
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: benchmark_integration_api.html
+permalink: benchmark_integration_api
 folder: docs
 ---
 
@@ -48,15 +48,15 @@ Note that for enumerations, i.e., for parameters that have a fixed set of possib
 
 ### Communication
 
-The communication between the benchmark controller and the platform is mainly based on the  [command queue](/command_queue.html) and predefined command IDs.
+The communication between the benchmark controller and the platform is mainly based on the  [command queue](/command_queue) and predefined command IDs.
 
 #### Benchmark initialization
 
-The platform expects the benchmark controller to send the [`BENCHMARK_READY_SIGNAL`](https://hobbit-project.github.io/command_queue.html#predefined-command-ids) via the command queue after the benchmark is initialized. Note that the benchmarking is not started as long as this message has not been received.
+The platform expects the benchmark controller to send the [`BENCHMARK_READY_SIGNAL`](https://hobbit-project.github.io/command_queue#predefined-command-ids) via the command queue after the benchmark is initialized. Note that the benchmarking is not started as long as this message has not been received.
 
 #### Benchmark start
 
-Note that the benchmark will have to wait for the platform controller to send the [`START_BENCHMARK_SIGNAL`](https://hobbit-project.github.io/command_queue.html#predefined-command-ids) via the command queue. Only after receiving this signal, the benchmark controller is allowed to start benchmarking the system. Note that this message contains the container name of the systems main container, i.e., from that point in time on, the benchmark itself is responsible to react if the system terminates (see the [container termination](https://hobbit-project.github.io/platform_api.html#container-termination) section for information about receiving the information about a terminated container). The start message has the following structure:
+Note that the benchmark will have to wait for the platform controller to send the [`START_BENCHMARK_SIGNAL`](https://hobbit-project.github.io/command_queue#predefined-command-ids) via the command queue. Only after receiving this signal, the benchmark controller is allowed to start benchmarking the system. Note that this message contains the container name of the systems main container, i.e., from that point in time on, the benchmark itself is responsible to react if the system terminates (see the [container termination](https://hobbit-project.github.io/platform_api#container-termination) section for information about receiving the information about a terminated container). The start message has the following structure:
 
 | start byte | length | meaning |
 |---|---|---|
@@ -96,7 +96,7 @@ The platform controller offers an API to the system which offers
 * the creation of new containers and
 * the termination of previously started containers.
 
-The API is described [here](https://hobbit-project.github.io/platform_api.html) in detail.
+The API is described [here](https://hobbit-project.github.io/platform_api) in detail.
 
 ## Benchmark meta data file
 

--- a/pages/docs/benchmark_integration_api.md
+++ b/pages/docs/benchmark_integration_api.md
@@ -52,11 +52,11 @@ The communication between the benchmark controller and the platform is mainly ba
 
 #### Benchmark initialization
 
-The platform expects the benchmark controller to send the [`BENCHMARK_READY_SIGNAL`](https://hobbit-project.github.io/command_queue#predefined-command-ids) via the command queue after the benchmark is initialized. Note that the benchmarking is not started as long as this message has not been received.
+The platform expects the benchmark controller to send the [`BENCHMARK_READY_SIGNAL`](/command_queue#predefined-command-ids) via the command queue after the benchmark is initialized. Note that the benchmarking is not started as long as this message has not been received.
 
 #### Benchmark start
 
-Note that the benchmark will have to wait for the platform controller to send the [`START_BENCHMARK_SIGNAL`](https://hobbit-project.github.io/command_queue#predefined-command-ids) via the command queue. Only after receiving this signal, the benchmark controller is allowed to start benchmarking the system. Note that this message contains the container name of the systems main container, i.e., from that point in time on, the benchmark itself is responsible to react if the system terminates (see the [container termination](https://hobbit-project.github.io/platform_api#container-termination) section for information about receiving the information about a terminated container). The start message has the following structure:
+Note that the benchmark will have to wait for the platform controller to send the [`START_BENCHMARK_SIGNAL`](/command_queue#predefined-command-ids) via the command queue. Only after receiving this signal, the benchmark controller is allowed to start benchmarking the system. Note that this message contains the container name of the systems main container, i.e., from that point in time on, the benchmark itself is responsible to react if the system terminates (see the [container termination](/platform_api#container-termination) section for information about receiving the information about a terminated container). The start message has the following structure:
 
 | start byte | length | meaning |
 |---|---|---|
@@ -96,7 +96,7 @@ The platform controller offers an API to the system which offers
 * the creation of new containers and
 * the termination of previously started containers.
 
-The API is described [here](https://hobbit-project.github.io/platform_api) in detail.
+The API is described [here](/platform_api) in detail.
 
 ## Benchmark meta data file
 

--- a/pages/docs/benchmarking.md
+++ b/pages/docs/benchmarking.md
@@ -3,11 +3,11 @@ title: Benchmarking a System
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: benchmarking.html
+permalink: benchmarking
 folder: docs
 ---
 
-Being a registered user of the platform and [having uploaded a system](/system_integration.html#3-create-and-push-the-docker-image) which conforms the specification (API) of one of the benchmarks allows the user to benchmark the system.
+Being a registered user of the platform and [having uploaded a system](/system_integration#3-create-and-push-the-docker-image) which conforms the specification (API) of one of the benchmarks allows the user to benchmark the system.
 The benchmarking of a system is done via the *Benchmarks* menu where at first the benchmark is selected to be used for the experiment. The drop down menu displays all possible benchmarks.
 
 ![Configuration of a benchmarking experiment. (a) Select the benchmark.](/images/10_Benchmark.png)

--- a/pages/docs/browsing_results.md
+++ b/pages/docs/browsing_results.md
@@ -3,7 +3,7 @@ title: Browsing Results
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: browsing_results.html
+permalink: browsing_results
 folder: docs
 ---
 

--- a/pages/docs/challenge_organization.md
+++ b/pages/docs/challenge_organization.md
@@ -3,7 +3,7 @@ title: Organizing a Challenge
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: challenge_organization.html
+permalink: challenge_organization
 folder: docs
 ---
 

--- a/pages/docs/challenge_participation.md
+++ b/pages/docs/challenge_participation.md
@@ -3,7 +3,7 @@ title: Taking Part in Challenge
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: challenge_participation.html
+permalink: challenge_participation
 folder: docs
 ---
 

--- a/pages/docs/command_queue.md
+++ b/pages/docs/command_queue.md
@@ -3,7 +3,7 @@ title: Command Queue
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: command_queue.html
+permalink: command_queue
 folder: docs
 ---
 
@@ -25,7 +25,7 @@ It can be seen that the first part of a message contains the session id of the b
 
 ## API
 
-The command queue uses a RabbitMQ Exchange. Connecting a component to this exchange can be done as described in the [RabbitMQ Publish/Subscribe tutorial](https://www.rabbitmq.com/tutorials/tutorial-three-java.html). The exchange itself has to be setup with:
+The command queue uses a RabbitMQ Exchange. Connecting a component to this exchange can be done as described in the [RabbitMQ Publish/Subscribe tutorial](https://www.rabbitmq.com/tutorials/tutorial-three-java). The exchange itself has to be setup with:
 * `name="hobbit.command"`
 * `type="fanout"`
 * `durable=false`

--- a/pages/docs/exoframe.md
+++ b/pages/docs/exoframe.md
@@ -3,7 +3,7 @@ title: Automatic Platform Provisioning using Exoframe
 keywords: tutorials
 sidebar: main_sidebar
 toc: false
-permalink: exoframe.html
+permalink: exoframe
 folder: docs
 ---
 

--- a/pages/docs/experiment_workflow.md
+++ b/pages/docs/experiment_workflow.md
@@ -3,13 +3,13 @@ title: Experiment workflow
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: experiment_workflow.html
+permalink: experiment_workflow
 folder: docs
 ---
 
 ## Experiment Workflow
 
-The HOBBIT platform does not demand the implementation of a very detailed workflow. In fact, the platform itself has a small API which has to be implemented by the benchmark and the system for a hand full of necessary messages (the minimal API for the benchmark and the system will be explained in [How to integrate a Benchmark](/benchmark_integration.html)). Apart from that, the real workflow of the benchmarking is up to the benchmark and system developer.
+The HOBBIT platform does not demand the implementation of a very detailed workflow. In fact, the platform itself has a small API which has to be implemented by the benchmark and the system for a hand full of necessary messages (the minimal API for the benchmark and the system will be explained in [How to integrate a Benchmark](/benchmark_integration)). Apart from that, the real workflow of the benchmarking is up to the benchmark and system developer.
 
 However, since we want to support the development of benchmarks and system adapters, we defined a second, more fine grained workflow which is supported by our abstract Java class implementations.
 

--- a/pages/docs/faq.md
+++ b/pages/docs/faq.md
@@ -3,7 +3,7 @@ title: FAQ
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: faq.html
+permalink: faq
 folder: docs
 ---
 
@@ -87,7 +87,7 @@ Please make sure that you have no hyphen in the name of your variable as explain
 #### I have a system written in Java. Do I need to use Maven to be able to benchmark it?
 No.
 
-First of all, the System Adapter can be an own project separated from your original system project. In that case you can [follow the tutorial](/system_integration.html) and develop the system adapter using Maven and the following three approaches:
+First of all, the System Adapter can be an own project separated from your original system project. In that case you can [follow the tutorial](/system_integration) and develop the system adapter using Maven and the following three approaches:
 1. You can implement the System Adapter as a parallel container that communicates with your system through some API.
 1. The System Adapter wraps your program and starts it as a second process in the same container.
 1. The System Adapter executes your system as Java class (i.e., executes it in the same VM). For this solution, you need to include the jar file of your system in the system adapter in your pom file. This blog post explains how you can do that in Maven: http://mark.koli.ch/maven-add-local-jar-dependency-to-classpath

--- a/pages/docs/frontend_component.md
+++ b/pages/docs/frontend_component.md
@@ -3,7 +3,7 @@ title: Frontend Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: frontend_component.html
+permalink: frontend_component
 folder: docs
 ---
 

--- a/pages/docs/internal_challenge_workflow.md
+++ b/pages/docs/internal_challenge_workflow.md
@@ -3,7 +3,7 @@ title: Internal Challenge Wokflow
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: internal_challenge_workflow.html
+permalink: internal_challenge_workflow
 folder: docs
 ---
 

--- a/pages/docs/java_components.md
+++ b/pages/docs/java_components.md
@@ -3,7 +3,7 @@ title: Java Components
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: java_components.html
+permalink: java_components
 folder: docs
 ---
 
@@ -89,7 +89,7 @@ The lines add the AKSW repository containing the core library. Additionally, the
 
 ### The Component interface
 
-A single benchmark comprises several components (as described in the [platform overview](/overview.html)) and a system adapter can be seen as a single component as well. All these components should implement the `org.hobbit.core.components.Component` interface. It defines the following methods.
+A single benchmark comprises several components (as described in the [platform overview](/overview)) and a system adapter can be seen as a single component as well. All these components should implement the `org.hobbit.core.components.Component` interface. It defines the following methods.
 ```java
 	public void init() throws Exception;
 
@@ -175,7 +175,7 @@ public class ExampleComponent extends SomeAbstractExampleComponent {
 
 ### Using the command queue
 
-The abstract classes offer an easy usage of the [command queue](/command_queue.html). In most cases, a direct usage of the command queue shouldn't be necessary. However, the abstract classes offer the following methods to send a message to the command queue:
+The abstract classes offer an easy usage of the [command queue](/command_queue). In most cases, a direct usage of the command queue shouldn't be necessary. However, the abstract classes offer the following methods to send a message to the command queue:
 
 ```java
 protected void sendToCmdQueue(byte command) throws IOException;
@@ -228,11 +228,11 @@ This docker file tells Docker
 * that it should execute the `ComponentStarter` that will load our component (in this example it is the `ExampleDataGenerator`)
 
 ## Logging
-The offered abstract classes use the [slf4j](https://www.slf4j.org/) logging library with a [binding to log4j](https://www.slf4j.org/manual.html#swapping). However, using the abstract classes without additional configuration of the logging will lead to the following Warnings instead of log messages:
+The offered abstract classes use the [slf4j](https://www.slf4j.org/) logging library with a [binding to log4j](https://www.slf4j.org/manual#swapping). However, using the abstract classes without additional configuration of the logging will lead to the following Warnings instead of log messages:
 ```
 log4j:WARN No appenders could be found for logger (org.hobbit.benchmark.platform.Temp).
 log4j:WARN Please initialize the log4j system properly.
-log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
+log4j:WARN See http://logging.apache.org/log4j/1.2/faq#noconfig for more info.
 ```
 
 An easy way to configure a log4j appender is to add a `log4j.properties` file to the project (e.g., to `src/main/resources` in a maven project) that could have the following content:
@@ -244,7 +244,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
 ```
-This file defines a simple log appender that writes all log messages which have at least the log level `INFO` to the console. For more information on configuring log4j, please have a look at its documentation at http://logging.apache.org/log4j/1.2/index.html
+This file defines a simple log appender that writes all log messages which have at least the log level `INFO` to the console. For more information on configuring log4j, please have a look at its documentation at http://logging.apache.org/log4j/1.2/index
 
 If a different logging should be used and a bridge from slf4j to this logging is available, the log4j binding has to be excluded in your projects pom file using.
 ```

--- a/pages/docs/java_sdk.md
+++ b/pages/docs/java_sdk.md
@@ -3,7 +3,7 @@ title: Java SDK
 keywords: tutorials
 sidebar: main_sidebar
 toc: false
-permalink: java_sdk.html
+permalink: java_sdk
 folder: docs
 ---
 
@@ -20,7 +20,7 @@ The SDK helps platform users with the following tasks:
 
 ### Creating a benchmark
 
-Make sure you have all [HOBBIT requirements](/requirements.html) met.
+Make sure you have all [HOBBIT requirements](/requirements) met.
 
 Clone [Java SDK Example kit](https://github.com/hobbit-project/java-sdk-example/)
 which contains a template for a benchmark.
@@ -47,7 +47,7 @@ Now, you can test the benchmark using Docker containers:
 After that, the benchmark image is ready and can be `docker push`-ed
 to remote repository.
 
-As usual, you'll need to add [a `.ttl` file](/benchmark_integration_api.html) describing your benchmark.
+As usual, you'll need to add [a `.ttl` file](/benchmark_integration_api) describing your benchmark.
 
 For more details, consult
 [HOBBIT Java SDK Example kit README](https://github.com/hobbit-project/java-sdk-example).

--- a/pages/docs/logging_component.md
+++ b/pages/docs/logging_component.md
@@ -3,7 +3,7 @@ title: Logging Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: logging_component.html
+permalink: logging_component
 folder: docs
 ---
 

--- a/pages/docs/master.md
+++ b/pages/docs/master.md
@@ -2,7 +2,7 @@
 title: Using Master Instance
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
-permalink: master.html
+permalink: master
 folder: docs
 ---
 
@@ -27,18 +27,18 @@ If you are participating in a challenge as a team, it is sufficient to have one 
 
 Every system that should be benchmarked on the Hobbit platform needs to be uploaded to it. This uploading comprises several steps. Note that a user profile is necessary to have the right to upload something to the platform.
 
-1. Before uploading something, an adapter for the system needs to be developed, so that the system fits into the platform and is able to interact with the benchmark with which it should be benchmarked. The general development of the adapter is [described here](/system_integration.html).
-2. The second step is the creation of a project in the [gitlab instance](http://git.project-hobbit.eu) of the platform. For that you can use the same account as for the platform itself. (The project should have the same name as the system. Please have a look at the [image upload](/system_integration.html) and its hints regarding the project name.)
-3. After creating a git project, you need to push the Docker image to the git project as [described here](/system_integration.html).
-4. The final step is to put the meta data describing your system into a file called `system.ttl` and push it to the git project. The format of the file is [described here](/system_integration.html).
+1. Before uploading something, an adapter for the system needs to be developed, so that the system fits into the platform and is able to interact with the benchmark with which it should be benchmarked. The general development of the adapter is [described here](/system_integration).
+2. The second step is the creation of a project in the [gitlab instance](http://git.project-hobbit.eu) of the platform. For that you can use the same account as for the platform itself. (The project should have the same name as the system. Please have a look at the [image upload](/system_integration) and its hints regarding the project name.)
+3. After creating a git project, you need to push the Docker image to the git project as [described here](/system_integration).
+4. The final step is to put the meta data describing your system into a file called `system.ttl` and push it to the git project. The format of the file is [described here](/system_integration).
 
-After uploading a system, [starting an experiment](/benchmarking.html) including the uploaded system and the benchmark for which the adapter has been implemented is recommended to make sure that the adapter is working as expected.
+After uploading a system, [starting an experiment](/benchmarking) including the uploaded system and the benchmark for which the adapter has been implemented is recommended to make sure that the adapter is working as expected.
 
 ## Upload a Benchmark
 
 Every benchmark that should be run on the Hobbit platform needs to be uploaded to it. This uploading comprises several steps. Note that a user profile is necessary to have the right to upload something to the platform.
 
-1. Before uploading, the benchmark has to be implemented in a way that it fits into the platform and is able to interact with the paltform controller. The general development of a benchmark is [described here](/benchmark_integration.html).
-2. The second step is the creation of at least one project in the [gitlab instance](http://git.project-hobbit.eu) of the platform. For that you can use the same account as for the platform itself. (The project should have the same name as the system. Please have a look at the [image upload](/system_integration.html) and its hints regarding the project name.)
-3. After creating the git project(s), you need to push the Docker image(s) to the git project(s) as [described here](/system_integration.html).
-4. The final step is to put the meta data describing the benchmark into a file called `benchmark.ttl` and push it to one of the git projects. The format of the file is [described here](/benchmark_integration_api.html).
+1. Before uploading, the benchmark has to be implemented in a way that it fits into the platform and is able to interact with the paltform controller. The general development of a benchmark is [described here](/benchmark_integration).
+2. The second step is the creation of at least one project in the [gitlab instance](http://git.project-hobbit.eu) of the platform. For that you can use the same account as for the platform itself. (The project should have the same name as the system. Please have a look at the [image upload](/system_integration) and its hints regarding the project name.)
+3. After creating the git project(s), you need to push the Docker image(s) to the git project(s) as [described here](/system_integration).
+4. The final step is to put the meta data describing the benchmark into a file called `benchmark.ttl` and push it to one of the git projects. The format of the file is [described here](/benchmark_integration_api).

--- a/pages/docs/message_bus_component.md
+++ b/pages/docs/message_bus_component.md
@@ -3,7 +3,7 @@ title: Message Bus Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: message_bus_component.html
+permalink: message_bus_component
 folder: docs
 ---
 

--- a/pages/docs/monitoring_component.md
+++ b/pages/docs/monitoring_component.md
@@ -3,7 +3,7 @@ title: Resource Monitoring
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: monitoring_component.html
+permalink: monitoring_component
 folder: docs
 ---
 

--- a/pages/docs/optional_features.md
+++ b/pages/docs/optional_features.md
@@ -3,11 +3,11 @@ title: Optional platform features
 keywords: platform HOBBIT
 sidebar: main_sidebar
 toc: true
-permalink: optional_features.html
+permalink: optional_features
 folder: docs
 ---
 
-For the complete platform deployment see [Platform Deployment on Single Machine](/platform_deployment_single_machine.html) or [Platform Deployment in Cluster](/platform_deployment_cluster.html).
+For the complete platform deployment see [Platform Deployment on Single Machine](/platform_deployment_single_machine) or [Platform Deployment in Cluster](/platform_deployment_cluster).
 
 ## Elasticsearch Logstack Kibana
 

--- a/pages/docs/overview.md
+++ b/pages/docs/overview.md
@@ -3,7 +3,7 @@ title: Platform Overview
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: overview.html
+permalink: overview
 folder: docs
 ---
 
@@ -21,4 +21,4 @@ Internally, the platform is written in Java and its communication is based on [R
 
 It can be seen that the benchmarking of a system has three different phases. First, the system and the benchmark are created and initialized. Second, the benchmark starts to benchmark the system and stores its responses in the evaluation storage. Third, the system as well as other parts are terminated and the data in the evaluation storage is used to evaluate the system responses.
 
-[Experiment workflow](/experiment_workflow.html) explains that in more detail.
+[Experiment workflow](/experiment_workflow) explains that in more detail.

--- a/pages/docs/parameters_config.md
+++ b/pages/docs/parameters_config.md
@@ -3,7 +3,7 @@ title: Platform Config File
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: parameters_config.html
+permalink: parameters_config
 folder: docs
 ---
 

--- a/pages/docs/parameters_env.md
+++ b/pages/docs/parameters_env.md
@@ -3,7 +3,7 @@ title: Env. Variables
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: parameters_env.html
+permalink: parameters_env
 folder: docs
 ---
 

--- a/pages/docs/parameters_frontend.md
+++ b/pages/docs/parameters_frontend.md
@@ -3,7 +3,7 @@ title: Frontend
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: parameters_frontend.html
+permalink: parameters_frontend
 folder: docs
 ---
 

--- a/pages/docs/parameters_storage_init.md
+++ b/pages/docs/parameters_storage_init.md
@@ -3,7 +3,7 @@ title: storage-init.sh
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: parameters_storage_init.html
+permalink: parameters_storage_init
 folder: docs
 ---
 

--- a/pages/docs/parameters_volumes.md
+++ b/pages/docs/parameters_volumes.md
@@ -3,7 +3,7 @@ title: Volumes
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: parameters_volumes.html
+permalink: parameters_volumes
 folder: docs
 ---
 

--- a/pages/docs/platform_api.md
+++ b/pages/docs/platform_api.md
@@ -9,7 +9,7 @@ folder: docs
 
 The platform offers a general API for the benchmark and the benchmarked system. Using this API, a component can request the creation of additional components, e.g., a benchmark controller can request the creation of benchmark related components or a benchmarked system can request the creation of additional containers needed by the system. Additionally, created containers can be stopped and the platform controller will send messages regarding the termination of created containers.
 
-For the communication with the platform controller, the [command queue](https://hobbit-project.github.io/command_queue) is used.
+For the communication with the platform controller, the [command queue](/command_queue) is used.
 
 ## Environment variables
 
@@ -24,7 +24,7 @@ If an abstract component class from the `hobbit.core` library is used, `HOBBIT_R
 
 ## Creating a container
 
-Requesting the creation of a container is done by sending the [`Commands.DOCKER_CONTAINER_START`](https://hobbit-project.github.io/command_queue#predefined-command-ids) id (=`0x0C`) on the command queue, followed by a JSON string containing the necessary information. Following the structure of [command queue messages](https://hobbit-project.github.io/command_queue#structure-of-a-message) such a request looks like the following:
+Requesting the creation of a container is done by sending the [`Commands.DOCKER_CONTAINER_START`](/command_queue#predefined-command-ids) id (=`0x0C`) on the command queue, followed by a JSON string containing the necessary information. Following the structure of [command queue messages](/command_queue#structure-of-a-message) such a request looks like the following:
 
 | start byte | length | meaning |
 |---|---|---|

--- a/pages/docs/platform_api.md
+++ b/pages/docs/platform_api.md
@@ -3,13 +3,13 @@ title: General API
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: platform_api.html
+permalink: platform_api
 folder: docs
 ---
 
 The platform offers a general API for the benchmark and the benchmarked system. Using this API, a component can request the creation of additional components, e.g., a benchmark controller can request the creation of benchmark related components or a benchmarked system can request the creation of additional containers needed by the system. Additionally, created containers can be stopped and the platform controller will send messages regarding the termination of created containers.
 
-For the communication with the platform controller, the [command queue](https://hobbit-project.github.io/command_queue.html) is used.
+For the communication with the platform controller, the [command queue](https://hobbit-project.github.io/command_queue) is used.
 
 ## Environment variables
 
@@ -24,7 +24,7 @@ If an abstract component class from the `hobbit.core` library is used, `HOBBIT_R
 
 ## Creating a container
 
-Requesting the creation of a container is done by sending the [`Commands.DOCKER_CONTAINER_START`](https://hobbit-project.github.io/command_queue.html#predefined-command-ids) id (=`0x0C`) on the command queue, followed by a JSON string containing the necessary information. Following the structure of [command queue messages](https://hobbit-project.github.io/command_queue.html#structure-of-a-message) such a request looks like the following:
+Requesting the creation of a container is done by sending the [`Commands.DOCKER_CONTAINER_START`](https://hobbit-project.github.io/command_queue#predefined-command-ids) id (=`0x0C`) on the command queue, followed by a JSON string containing the necessary information. Following the structure of [command queue messages](https://hobbit-project.github.io/command_queue#structure-of-a-message) such a request looks like the following:
 
 | start byte | length | meaning |
 |---|---|---|

--- a/pages/docs/platform_controller_component.md
+++ b/pages/docs/platform_controller_component.md
@@ -3,7 +3,7 @@ title: Platform Controller Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: platform_controller_component.html
+permalink: platform_controller_component
 folder: docs
 ---
 

--- a/pages/docs/platform_deployment_cluster.md
+++ b/pages/docs/platform_deployment_cluster.md
@@ -3,7 +3,7 @@ title: Platform Deployment
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: platform_deployment_cluster.html
+permalink: platform_deployment_cluster
 folder: docs
 ---
 

--- a/pages/docs/platform_deployment_single_machine.md
+++ b/pages/docs/platform_deployment_single_machine.md
@@ -3,11 +3,11 @@ title: Platform Deployment
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: platform_deployment_single_machine.html
+permalink: platform_deployment_single_machine
 folder: docs
 ---
 
-For the quick start check out [quick platform deployment guide](/quick_guide.html).
+For the quick start check out [quick platform deployment guide](/quick_guide).
 
 ## Preparing
 
@@ -191,8 +191,8 @@ docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)
 ## Troubleshooting
 
 If you encounter problems setting up the platform, please have a look at
-[Troubleshooting](/troubleshooting.html)
-and [FAQ](/faq.html).
+[Troubleshooting](/troubleshooting)
+and [FAQ](/faq).
 
 ### Regular cleaning of dangling Docker images
 Depending on the way the platform is used, it can download many Docker images over time. Note that Docker itself won't delete but keep all versions of these images. To save disk space, a regular cleaning of dangling images is helpful.

--- a/pages/docs/quick_guide.md
+++ b/pages/docs/quick_guide.md
@@ -3,11 +3,11 @@ title: Quick Guide
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: quick_guide.html
+permalink: quick_guide
 folder: docs
 ---
 
-1. Make sure you've got all [requirements](/requirements.html) installed.
+1. Make sure you've got all [requirements](/requirements) installed.
 
 1. Clone the repository:
 ```
@@ -46,7 +46,7 @@ After the platform startup, the following interfaces will be available for you:
 (Virtuoso)
 
 Now, when you've got a running platform,
-you can [benchmark a system](/benchmarking.html).
+you can [benchmark a system](/benchmarking).
 
 ## Optional Steps
 

--- a/pages/docs/repository_component.md
+++ b/pages/docs/repository_component.md
@@ -3,7 +3,7 @@ title: Repository Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: repository_component.html
+permalink: repository_component
 folder: docs
 ---
 

--- a/pages/docs/requirements.md
+++ b/pages/docs/requirements.md
@@ -3,7 +3,7 @@ title: Requirements for the HOBBIT Platform
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: requirements.html
+permalink: requirements
 folder: docs
 ---
 

--- a/pages/docs/storage_component.md
+++ b/pages/docs/storage_component.md
@@ -3,7 +3,7 @@ title: Storage Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: storage_component.html
+permalink: storage_component
 folder: docs
 ---
 

--- a/pages/docs/system_integration.md
+++ b/pages/docs/system_integration.md
@@ -3,11 +3,11 @@ title: Integrating Your Own Code
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: system_integration.html
+permalink: system_integration
 folder: docs
 ---
 
-This tutorial shows how a system can be prepared to be benchmarked within the HOBBIT platform. The tutorial mainly covers all necessary steps including the development of a System Adapter in Java. Note that the adapter can be implemented in other languages as well. However, for Java we are offering a library which eases the implementation. For other languages, you may want to take a look into the [System API](/system_integration_api.html).
+This tutorial shows how a system can be prepared to be benchmarked within the HOBBIT platform. The tutorial mainly covers all necessary steps including the development of a System Adapter in Java. Note that the adapter can be implemented in other languages as well. However, for Java we are offering a library which eases the implementation. For other languages, you may want to take a look into the [System API](/system_integration_api).
 
 A system that should be benchmark within the HOBBIT platform needs to fulfill the following requirements:
 1. Be encapsulated in a Docker image
@@ -153,9 +153,9 @@ We will go through the different methods to clarify their meaning:
 1. `receiveGeneratedTask` is the method which is called if your system receives a task that should be fulfilled. Based on the data that you receive, your system should generate the result the benchmark is assuming and send it back using the `sendResultToEvalStorage` method. Please check the benchmarks API for the format that the data of the task will have and which format the (serialized) result should have.
 1. `close` is the method which will be called at the end after the benchmarking is done and your system is asked to shut down. Make sure that `super.close()` is the last method called this method.
 
-Note that there are additional methods which could be overriden by your class if you want to make use of them. An overview of these methods can be found at [System API](/system_integration_api.html).
+Note that there are additional methods which could be overriden by your class if you want to make use of them. An overview of these methods can be found at [System API](/system_integration_api).
 
-One of possibilities to manage communication with the system is to write a system adapter as a wrapper. Other options are described at [System API](/system_integration_api.html).
+One of possibilities to manage communication with the system is to write a system adapter as a wrapper. Other options are described at [System API](/system_integration_api).
 
 ### 2.a. The System Adapter as wrapper
 

--- a/pages/docs/system_integration_api.md
+++ b/pages/docs/system_integration_api.md
@@ -3,7 +3,7 @@ title: Integrating a System
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: system_integration_api.html
+permalink: system_integration_api
 folder: docs
 ---
 
@@ -32,11 +32,11 @@ After the container started, the platform assumes that it will connect itself to
 
 ### Communication
 
-The platform expects the system container to send the [`SYSTEM_READY_SIGNAL`](https://hobbit-project.github.io/command_queue.html#predefined-command-ids) via the command queue after the system is initialized. Note that the benchmarking is not started as long as this message has not been received. It should also be mentioned that from that moment on, the benchmark is allowed to bombard the system with messages. So the system should be fully up and running when sending this message.
+The platform expects the system container to send the [`SYSTEM_READY_SIGNAL`](https://hobbit-project.github.io/command_queue#predefined-command-ids) via the command queue after the system is initialized. Note that the benchmarking is not started as long as this message has not been received. It should also be mentioned that from that moment on, the benchmark is allowed to bombard the system with messages. So the system should be fully up and running when sending this message.
 
 #### Benchmark API Communication
 
-Apart from that, the system container will have to implement the benchmark API. If the benchmark is relying on [our proposed workflow](https://hobbit-project.github.io/experiment_workflow.html), the system adapter should listen to the command queue for the [`TASK_GENERATION_FINISHED`](https://hobbit-project.github.io/command_queue.html#predefined-command-ids) message. If this message is received, the benchmark informs the system that there won't be any new tasks generated. They system should process all remaining tasks and terminate.
+Apart from that, the system container will have to implement the benchmark API. If the benchmark is relying on [our proposed workflow](https://hobbit-project.github.io/experiment_workflow), the system adapter should listen to the command queue for the [`TASK_GENERATION_FINISHED`](https://hobbit-project.github.io/command_queue#predefined-command-ids) message. If this message is received, the benchmark informs the system that there won't be any new tasks generated. They system should process all remaining tasks and terminate.
 
 ### Container termination
 
@@ -50,7 +50,7 @@ The platform controller offers an API to the system which offers
 * the creation of new containers and
 * the termination of previously started containers.
 
-The API is described [here](https://hobbit-project.github.io/platform_api.html) in detail.
+The API is described [here](https://hobbit-project.github.io/platform_api) in detail.
 
 ## System meta data file
 

--- a/pages/docs/transferring_data.md
+++ b/pages/docs/transferring_data.md
@@ -2,7 +2,7 @@
 title: Transferring Data
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
-permalink: transferring_data.html
+permalink: transferring_data
 folder: docs
 ---
 

--- a/pages/docs/troubleshooting.md
+++ b/pages/docs/troubleshooting.md
@@ -3,7 +3,7 @@ title: Troubleshooting
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: troubleshooting.html
+permalink: troubleshooting
 folder: docs
 ---
 

--- a/pages/docs/user_management_component.md
+++ b/pages/docs/user_management_component.md
@@ -3,7 +3,7 @@ title: User Management Component
 keywords: HOBBIT Documentation
 sidebar: main_sidebar
 toc: false
-permalink: user_management_component.html
+permalink: user_management_component
 folder: docs
 ---
 


### PR DESCRIPTION
Old links still continue to work, so they won't break.